### PR TITLE
transfer --help option improvements and examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+sudo: required
+before_install:
+    - sudo add-apt-repository -y ppa:fish-shell/release-2
+    - sudo apt-get update
+    - sudo apt-get -y install fish
+script:
+    - curl -Lo ~/.config/fish/functions/fisher.fish --create-dirs https://git.io/fisher
+    - fish -c "fisher transfer"
+    - fish -c "transfer --help"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Upload to <https://transfer.sh>
 
 ## Install
 
-With [Fisherman](https://fisherman.github.io/)
+With [fisherman]
 
 ```
 fisher transfer

--- a/README.md
+++ b/README.md
@@ -29,3 +29,7 @@ transfer my-file.txt my-file-new-name.txt
 ```fish
 echo my message text | transfer my-message.txt
 ```
+
+```fish
+cat my-file.txt | transfer my-file-new-name.txt
+```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Upload to <https://transfer.sh>
 
 ## Install
 
-With [fisherman]
+With [Fisherman](https://fisherman.github.io/)
 
 ```
 fisher transfer

--- a/transfer.fish
+++ b/transfer.fish
@@ -6,7 +6,13 @@ function transfer -d "Upload to transfer.sh" -a file name
                 continue
 
             case h help
-                printf "Usage: transfer file name \n"
+                echo "Usage: transfer [FILE] [NAME]"
+                echo
+                echo "Examples:"
+                echo "      transfer my-file.txt"
+                echo "      transfer my-file.txt my-file-new-name.txt"
+                echo "      echo my message text | transfer my-message.txt"
+                echo "      cat my-file.txt | transfer my-file-new-name.txt"
                 return
 
             case \*


### PR DESCRIPTION
Inspired by [xclip](https://linux.die.net/man/1/xclip) :smile: 

> I hate man pages without examples!

Before:
```fish
~> transfer --help
Usage: transfer file name

```

After:
```fish
~> transfer --help
Usage: transfer [FILE] [NAME]

Examples:
      transfer my-file.txt
      transfer my-file.txt my-file-new-name.txt
      echo my message text | transfer my-message.txt
      cat my-file.txt | transfer my-file-new-name.txt
```

__Changelog:__

- [x] b1f61d9: More verbose `--help` output with examples.
- [x] d6bcdcd: One more example in `README.md` using `cat` with pipes.
- [x] 600b972: Add `travis.yml` file.


